### PR TITLE
Replace legacy caddr_t type with void*

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         name: mv-freertos-cmsis-demo-win-wsl
         path: ${{ github.workspace }}/build/Demo/mv-freertos-cmsis-demo.*
   build_mac_native:
-    name: Build on macOS with native tools
+    name: Build on macOS with native tooling
     runs-on: macos-latest
     steps:
     - name: Check out code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Get Pre-reqs
-      run: curl https://raw.githubusercontent.com/Homebrew/homebrew-cask/17d156bba668109dcb6bba337a75fcf41be2d71b/Casks/gcc-arm-embedded.rb -o gcc-arm-embedded.rb && brew install --cask gcc-arm-embedded.rb
+      run: brew install --cask gcc-arm-embedded
     - name: Build code
       run: cmake -S . -B build && cmake --build build
     - name: Upload artifacts

--- a/ST_Code/Core/Src/sysmem.c
+++ b/ST_Code/Core/Src/sysmem.c
@@ -60,7 +60,7 @@ register char * stack_ptr asm("sp");
  _sbrk
  Increase program data space. Malloc and related functions depend on this
 **/
-caddr_t _sbrk(int incr)
+void* _sbrk(int incr)
 {
 	extern char end asm("end");
 	static char *heap_end;
@@ -73,11 +73,11 @@ caddr_t _sbrk(int incr)
 	if (heap_end + incr > stack_ptr)
 	{
 		errno = ENOMEM;
-		return (caddr_t) -1;
+		return (void*) -1;
 	}
 
 	heap_end += incr;
 
-	return (caddr_t) prev_heap_end;
+	return (void*) prev_heap_end;
 }
 


### PR DESCRIPTION
Builds on macOS using the latest (13.2.1) version of ARM's gcc fail with `unknown type name 'caddr_t'`. This has been the case for a while (11.2.0 compiles the demo OK). This type is used in a single file, in the ST code we use.

[According to Stack Overflow](https://stackoverflow.com/questions/6381526/what-is-the-significance-of-caddr-t-and-when-is-it-used) `caddr_t` is a very, very old type that probably shouldn't be in the ST code. It's an alternative to `void*`.

I have replaced `caddr_t` with `void*` and the demo builds on macOS with the latest ARM gcc. It also builds on Linux with gcc 10.3.1 (our Linux supported version; it's what's installed with `sudo apt install gcc-arm-none-eabi`).

IMHO we should roll out this change to all the demo repos that use ST code. Question: where did the ST code come from? Has ST itself updated this since 2020 (the (c) date on the code)?