### PR TITLE
Fix macOS Docker GH action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         path: ${{ github.workspace }}/build/Demo/mv-freertos-cmsis-demo.*
   build_mac_docker:
     name: Build on macOS with Docker
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
     - name: Check out code
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Get Docker
-      run: brew install docker
+      run: brew install docker colima
     - name: Run Docker
       run: colima start
     - name: Build docker image


### PR DESCRIPTION
Revert to an older version of macOS to avoid Docker/Colima breakage on `macos-latest` (caused by GH use of Apple Silicon in emulation)